### PR TITLE
1116 init validation solidity v0.6

### DIFF
--- a/modules/cf-core/package.json
+++ b/modules/cf-core/package.json
@@ -22,7 +22,7 @@
     "@connext/utils": "6.3.13",
     "@connext/types": "6.3.13",
     "ethers": "4.0.47",
-    "@openzeppelin/contracts": "2.5.0",
+    "@openzeppelin/contracts": "3.0.1",
     "eventemitter3": "4.0.0",
     "memoizee": "0.4.14",
     "p-queue": "6.4.0",

--- a/modules/contracts/buidler.config.ts
+++ b/modules/contracts/buidler.config.ts
@@ -18,8 +18,7 @@ const config: BuidlerConfig = {
     artifacts: "./build",
   },
   solc: {
-    version: "0.5.11", // Note that this only has the version number
-    evmVersion: "constantinople",
+    version: "0.6.7", // Note that this only has the version number
   },
   defaultNetwork: "buidlerevm",
   networks: {

--- a/modules/contracts/contracts/adjudicator/ChallengeRegistry.sol
+++ b/modules/contracts/contracts/adjudicator/ChallengeRegistry.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.5.11;
+pragma solidity 0.6.7;
 pragma experimental "ABIEncoderV2";
 
 import "./mixins/MixinChallengeRegistryCore.sol";

--- a/modules/contracts/contracts/adjudicator/interfaces/CounterfactualApp.sol
+++ b/modules/contracts/contracts/adjudicator/interfaces/CounterfactualApp.sol
@@ -27,6 +27,8 @@ contract CounterfactualApp is CounterfactualAppInterface {
     }
 
     function init(bytes calldata)
+        override
+        virtual
         external
         view
         returns (bool)

--- a/modules/contracts/contracts/adjudicator/interfaces/CounterfactualApp.sol
+++ b/modules/contracts/contracts/adjudicator/interfaces/CounterfactualApp.sol
@@ -1,10 +1,14 @@
-pragma solidity 0.5.11;
+pragma solidity 0.6.7;
 pragma experimental "ABIEncoderV2";
 
+import "./CounterfactualAppInterface.sol";
 
-contract CounterfactualApp {
+
+contract CounterfactualApp is CounterfactualAppInterface {
 
     function isStateTerminal(bytes calldata)
+        override
+        virtual
         external
         view
         returns (bool)
@@ -13,6 +17,8 @@ contract CounterfactualApp {
     }
 
     function getTurnTaker(bytes calldata, address[] calldata)
+        override
+        virtual
         external
         view
         returns (address)
@@ -29,6 +35,8 @@ contract CounterfactualApp {
     }
 
     function applyAction(bytes calldata, bytes calldata)
+        override
+        virtual
         external
         view
         returns (bytes memory)
@@ -37,6 +45,8 @@ contract CounterfactualApp {
     }
 
     function computeOutcome(bytes calldata)
+        override
+        virtual
         external
         view
         returns (bytes memory)

--- a/modules/contracts/contracts/adjudicator/interfaces/CounterfactualAppInterface.sol
+++ b/modules/contracts/contracts/adjudicator/interfaces/CounterfactualAppInterface.sol
@@ -1,0 +1,27 @@
+pragma solidity 0.6.7;
+pragma experimental "ABIEncoderV2";
+
+
+interface CounterfactualAppInterface {
+
+    function isStateTerminal(bytes calldata)
+        external
+        view
+        returns (bool);
+
+    function getTurnTaker(bytes calldata, address[] calldata)
+        external
+        view
+        returns (address);
+
+    function applyAction(bytes calldata, bytes calldata)
+        external
+        view
+        returns (bytes memory);
+
+    function computeOutcome(bytes calldata)
+        external
+        view
+        returns (bytes memory);
+
+}

--- a/modules/contracts/contracts/adjudicator/interfaces/CounterfactualAppInterface.sol
+++ b/modules/contracts/contracts/adjudicator/interfaces/CounterfactualAppInterface.sol
@@ -14,6 +14,11 @@ interface CounterfactualAppInterface {
         view
         returns (address);
 
+    function init(bytes calldata)
+        external
+        view
+        returns (bool);
+
     function applyAction(bytes calldata, bytes calldata)
         external
         view

--- a/modules/contracts/contracts/adjudicator/libs/LibAppCaller.sol
+++ b/modules/contracts/contracts/adjudicator/libs/LibAppCaller.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.5.11;
+pragma solidity 0.6.7;
 pragma experimental "ABIEncoderV2";
 
 import "../interfaces/CounterfactualApp.sol";

--- a/modules/contracts/contracts/adjudicator/libs/LibDispute.sol
+++ b/modules/contracts/contracts/adjudicator/libs/LibDispute.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.5.11;
+pragma solidity 0.6.7;
 pragma experimental ABIEncoderV2;
 
 

--- a/modules/contracts/contracts/adjudicator/libs/LibStateChannelApp.sol
+++ b/modules/contracts/contracts/adjudicator/libs/LibStateChannelApp.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.5.11;
+pragma solidity 0.6.7;
 pragma experimental ABIEncoderV2;
 
 import "@openzeppelin/contracts/math/SafeMath.sol";
@@ -66,7 +66,7 @@ contract LibStateChannelApp is LibDispute {
         AppChallenge memory appChallenge
     )
         public
-        view
+        pure
         returns (bool)
     {
         return appChallenge.status == ChallengeStatus.OUTCOME_SET;

--- a/modules/contracts/contracts/adjudicator/mixins/MChallengeRegistryCore.sol
+++ b/modules/contracts/contracts/adjudicator/mixins/MChallengeRegistryCore.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.5.11;
+pragma solidity 0.6.7;
 pragma experimental "ABIEncoderV2";
 
 import "../../shared/libs/LibCommitment.sol";

--- a/modules/contracts/contracts/adjudicator/mixins/MixinCancelDispute.sol
+++ b/modules/contracts/contracts/adjudicator/mixins/MixinCancelDispute.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.5.11;
+pragma solidity 0.6.7;
 pragma experimental "ABIEncoderV2";
 
 import "../libs/LibStateChannelApp.sol";

--- a/modules/contracts/contracts/adjudicator/mixins/MixinChallengeRegistryCore.sol
+++ b/modules/contracts/contracts/adjudicator/mixins/MixinChallengeRegistryCore.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.5.11;
+pragma solidity 0.6.7;
 pragma experimental "ABIEncoderV2";
 
 import "../libs/LibStateChannelApp.sol";

--- a/modules/contracts/contracts/adjudicator/mixins/MixinProgressState.sol
+++ b/modules/contracts/contracts/adjudicator/mixins/MixinProgressState.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.5.11;
+pragma solidity 0.6.7;
 pragma experimental "ABIEncoderV2";
 
 import "../libs/LibStateChannelApp.sol";

--- a/modules/contracts/contracts/adjudicator/mixins/MixinSetAndProgressState.sol
+++ b/modules/contracts/contracts/adjudicator/mixins/MixinSetAndProgressState.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.5.11;
+pragma solidity 0.6.7;
 pragma experimental "ABIEncoderV2";
 
 import "../libs/LibDispute.sol";

--- a/modules/contracts/contracts/adjudicator/mixins/MixinSetOutcome.sol
+++ b/modules/contracts/contracts/adjudicator/mixins/MixinSetOutcome.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.5.11;
+pragma solidity 0.6.7;
 pragma experimental "ABIEncoderV2";
 
 import "../libs/LibStateChannelApp.sol";

--- a/modules/contracts/contracts/adjudicator/mixins/MixinSetState.sol
+++ b/modules/contracts/contracts/adjudicator/mixins/MixinSetState.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.5.11;
+pragma solidity 0.6.7;
 pragma experimental "ABIEncoderV2";
 
 import "../libs/LibStateChannelApp.sol";

--- a/modules/contracts/contracts/adjudicator/test-fixtures/AppApplyActionFails.sol
+++ b/modules/contracts/contracts/adjudicator/test-fixtures/AppApplyActionFails.sol
@@ -11,8 +11,9 @@ import "./AppWithAction.sol";
 contract AppApplyActionFails is AppWithAction {
 
     function init(
-        bytes calldata encodedState
+        bytes calldata /* encodedState */
     )
+        override
         external
         view
         returns (bool)

--- a/modules/contracts/contracts/adjudicator/test-fixtures/AppApplyActionFails.sol
+++ b/modules/contracts/contracts/adjudicator/test-fixtures/AppApplyActionFails.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.5.11;
+pragma solidity 0.6.7;
 pragma experimental "ABIEncoderV2";
 
 import "./AppWithAction.sol";
@@ -21,12 +21,13 @@ contract AppApplyActionFails is AppWithAction {
     }
 
     function applyAction(
-        bytes calldata encodedState,
-        bytes calldata encodedAction
+        bytes calldata /* encodedState */,
+        bytes calldata /* encodedAction */
     )
+        override
         external
         view
-        returns (bytes memory ret)
+        returns (bytes memory)
     {
         revert("applyAction fails for this app");
     }

--- a/modules/contracts/contracts/adjudicator/test-fixtures/AppComputeOutcomeFails.sol
+++ b/modules/contracts/contracts/adjudicator/test-fixtures/AppComputeOutcomeFails.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.5.11;
+pragma solidity 0.6.7;
 pragma experimental "ABIEncoderV2";
 
 import "./AppWithAction.sol";
@@ -19,6 +19,7 @@ contract AppComputeOutcomeFails is AppWithAction {
     }
 
     function computeOutcome(bytes calldata)
+        override
         external
         view
         returns (bytes memory)

--- a/modules/contracts/contracts/adjudicator/test-fixtures/AppComputeOutcomeFails.sol
+++ b/modules/contracts/contracts/adjudicator/test-fixtures/AppComputeOutcomeFails.sol
@@ -11,6 +11,7 @@ import "./AppWithAction.sol";
 contract AppComputeOutcomeFails is AppWithAction {
 
     function init(bytes calldata)
+        override
         external
         view
         returns (bool)

--- a/modules/contracts/contracts/adjudicator/test-fixtures/AppWithAction.sol
+++ b/modules/contracts/contracts/adjudicator/test-fixtures/AppWithAction.sol
@@ -77,7 +77,9 @@ contract AppWithAction is CounterfactualApp {
         return abi.encode(state);
     }
 
-    function init(bytes calldata encodedState)
+    function init(bytes calldata)
+        override
+        virtual
         external
         view
         returns (bool)

--- a/modules/contracts/contracts/adjudicator/test-fixtures/AppWithAction.sol
+++ b/modules/contracts/contracts/adjudicator/test-fixtures/AppWithAction.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.5.11;
+pragma solidity 0.6.7;
 pragma experimental "ABIEncoderV2";
 
 import "../interfaces/CounterfactualApp.sol";
@@ -35,6 +35,7 @@ contract AppWithAction is CounterfactualApp {
         bytes calldata encodedState,
         address[] calldata participants
     )
+        override
         external
         view
         returns (address)
@@ -44,6 +45,8 @@ contract AppWithAction is CounterfactualApp {
     }
 
     function computeOutcome(bytes calldata)
+        override
+        virtual
         external
         view
         returns (bytes memory)
@@ -55,6 +58,8 @@ contract AppWithAction is CounterfactualApp {
         bytes calldata encodedState,
         bytes calldata encodedAction
     )
+        override
+        virtual
         external
         view
         returns (bytes memory ret)
@@ -81,6 +86,7 @@ contract AppWithAction is CounterfactualApp {
     }
 
     function isStateTerminal(bytes calldata encodedState)
+        override
         external
         view
         returns (bool)

--- a/modules/contracts/contracts/apps/HashLockTransferApp.sol
+++ b/modules/contracts/contracts/apps/HashLockTransferApp.sol
@@ -28,6 +28,7 @@ contract HashLockTransferApp is CounterfactualApp {
     }
 
     function init(bytes calldata encodedState)
+        override
         external
         view
         returns(bool)

--- a/modules/contracts/contracts/apps/HashLockTransferApp.sol
+++ b/modules/contracts/contracts/apps/HashLockTransferApp.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.5.11;
+pragma solidity 0.6.7;
 pragma experimental "ABIEncoderV2";
 
 import "../adjudicator/interfaces/CounterfactualApp.sol";
@@ -48,6 +48,7 @@ contract HashLockTransferApp is CounterfactualApp {
         bytes calldata encodedState,
         bytes calldata encodedAction
     )
+        override
         external
         view
         returns (bytes memory)
@@ -69,6 +70,7 @@ contract HashLockTransferApp is CounterfactualApp {
     }
 
     function computeOutcome(bytes calldata encodedState)
+        override
         external
         view
         returns (bytes memory)
@@ -84,9 +86,10 @@ contract HashLockTransferApp is CounterfactualApp {
     }
 
     function getTurnTaker(
-        bytes calldata encodedState,
+        bytes calldata /* encodedState */,
         address[] calldata participants
     )
+        override
         external
         view
         returns (address)
@@ -95,6 +98,7 @@ contract HashLockTransferApp is CounterfactualApp {
     }
 
     function isStateTerminal(bytes calldata encodedState)
+        override
         external
         view
         returns (bool)

--- a/modules/contracts/contracts/apps/HighRollerApp.sol
+++ b/modules/contracts/contracts/apps/HighRollerApp.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.5.11;
+pragma solidity 0.6.7;
 pragma experimental "ABIEncoderV2";
 
 import "../adjudicator/interfaces/CounterfactualApp.sol";
@@ -56,6 +56,7 @@ contract HighRollerApp is CounterfactualApp {
     }
 
     function isStateTerminal(bytes calldata encodedState)
+        override
         external
         view
         returns (bool)
@@ -72,6 +73,7 @@ contract HighRollerApp is CounterfactualApp {
         bytes calldata encodedState,
         address[] calldata participants
     )
+        override
         external
         view
         returns (address)
@@ -84,6 +86,7 @@ contract HighRollerApp is CounterfactualApp {
         bytes calldata encodedState,
         bytes calldata encodedAction
     )
+        override
         external
         view
         returns (bytes memory)
@@ -154,6 +157,7 @@ contract HighRollerApp is CounterfactualApp {
     }
 
     function computeOutcome(bytes calldata encodedState)
+        override
         external
         view
         returns (bytes memory)
@@ -192,7 +196,7 @@ contract HighRollerApp is CounterfactualApp {
 
     function highRoller(bytes32 randomness)
         public
-        view
+        pure
         returns(uint8 playerFirstTotal, uint8 playerSecondTotal)
     {
         (
@@ -207,7 +211,7 @@ contract HighRollerApp is CounterfactualApp {
 
     function getPlayerRolls(bytes32 randomness)
         public // NOTE: This is used in app-root.tsx for the clientside dapp
-        view
+        pure
         returns(uint8 playerFirstRollOne, uint8 playerFirstRollTwo, uint8 playerSecondRollOne, uint8 playerSecondRollTwo)
     {
         (
@@ -224,7 +228,7 @@ contract HighRollerApp is CounterfactualApp {
 
     function getWinningAmounts(uint256 num1, uint256 num2)
         internal
-        view
+        pure
         returns (LibOutcome.TwoPartyFixedOutcome)
     {
         bytes32 randomSalt = calculateRandomSalt(num1, num2);
@@ -245,7 +249,7 @@ contract HighRollerApp is CounterfactualApp {
 
     function calculateRandomSalt(uint256 num1, uint256 num2)
         internal
-        view
+        pure
         returns (bytes32)
     {
         return keccak256(abi.encodePacked(num1 * num2));
@@ -258,7 +262,7 @@ contract HighRollerApp is CounterfactualApp {
     ///      string (e.g., 0x08, 0x10) by incrementing by 8 bytes each time.
     function cutBytes32(bytes32 h)
         internal
-        view
+        pure
         returns (bytes8 q1, bytes8 q2, bytes8 q3, bytes8 q4)
     {
         assembly {
@@ -276,7 +280,7 @@ contract HighRollerApp is CounterfactualApp {
     /// @dev Splits this by using modulo 6 to get the uint
     function bytes8toDiceRoll(bytes8 q)
       internal
-      view
+      pure
       returns (uint8)
     {
         return uint8(uint64(q) % 6);

--- a/modules/contracts/contracts/apps/HighRollerApp.sol
+++ b/modules/contracts/contracts/apps/HighRollerApp.sol
@@ -47,7 +47,8 @@ contract HighRollerApp is CounterfactualApp {
         bytes32 actionHash;
     }
 
-    function init(bytes calldata encodedState)
+    function init(bytes calldata /* encodedState */)
+        override
         external
         view
         returns(bool)

--- a/modules/contracts/contracts/apps/NimApp.sol
+++ b/modules/contracts/contracts/apps/NimApp.sol
@@ -21,7 +21,8 @@ contract NimApp is CounterfactualApp {
         uint256[3] pileHeights;
     }
 
-    function init(bytes calldata encodedState)
+    function init(bytes calldata /* encodedState */)
+        override
         external
         view
         returns(bool)

--- a/modules/contracts/contracts/apps/NimApp.sol
+++ b/modules/contracts/contracts/apps/NimApp.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.5.11;
+pragma solidity 0.6.7;
 pragma experimental "ABIEncoderV2";
 
 import "../adjudicator/interfaces/CounterfactualApp.sol";
@@ -30,6 +30,7 @@ contract NimApp is CounterfactualApp {
     }
 
     function isStateTerminal(bytes calldata encodedState)
+        override
         external
         view
         returns (bool)
@@ -43,6 +44,7 @@ contract NimApp is CounterfactualApp {
         bytes calldata encodedState,
         address[] calldata participants
     )
+        override
         external
         view
         returns (address)
@@ -54,6 +56,7 @@ contract NimApp is CounterfactualApp {
     function applyAction(
         bytes calldata encodedState, bytes calldata encodedAction
     )
+        override
         external
         view
         returns (bytes memory)
@@ -75,6 +78,7 @@ contract NimApp is CounterfactualApp {
     }
 
     function computeOutcome(bytes calldata encodedState)
+        override
         external
         view
         returns (bytes memory)
@@ -90,7 +94,7 @@ contract NimApp is CounterfactualApp {
 
     function isWin(AppState memory state)
         internal
-        view
+        pure
         returns (bool)
     {
         return (

--- a/modules/contracts/contracts/apps/SimpleLinkedTransferApp.sol
+++ b/modules/contracts/contracts/apps/SimpleLinkedTransferApp.sol
@@ -37,6 +37,7 @@ contract SimpleLinkedTransferApp is CounterfactualApp {
     }
 
     function init(bytes calldata encodedState)
+        override
         external
         view
         returns(bool)

--- a/modules/contracts/contracts/apps/SimpleLinkedTransferApp.sol
+++ b/modules/contracts/contracts/apps/SimpleLinkedTransferApp.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.5.11;
+pragma solidity 0.6.7;
 pragma experimental "ABIEncoderV2";
 
 import "@openzeppelin/contracts/math/SafeMath.sol";
@@ -57,6 +57,7 @@ contract SimpleLinkedTransferApp is CounterfactualApp {
         bytes calldata encodedState,
         bytes calldata encodedAction
     )
+        override
         external
         view
         returns (bytes memory)
@@ -70,6 +71,7 @@ contract SimpleLinkedTransferApp is CounterfactualApp {
     }
 
     function computeOutcome(bytes calldata encodedState)
+        override
         external
         view
         returns (bytes memory)

--- a/modules/contracts/contracts/apps/SimpleSignedTransferApp.sol
+++ b/modules/contracts/contracts/apps/SimpleSignedTransferApp.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.5.11;
+pragma solidity 0.6.7;
 pragma experimental "ABIEncoderV2";
 
 import "@openzeppelin/contracts/math/SafeMath.sol";
@@ -46,6 +46,7 @@ contract SimpleSignedTransferApp is CounterfactualApp {
         bytes calldata encodedState,
         bytes calldata encodedAction
     )
+        override
         external
         view
         returns (bytes memory)
@@ -65,6 +66,7 @@ contract SimpleSignedTransferApp is CounterfactualApp {
     }
 
     function computeOutcome(bytes calldata encodedState)
+        override
         external
         view
         returns (bytes memory)
@@ -75,9 +77,10 @@ contract SimpleSignedTransferApp is CounterfactualApp {
     }
 
     function getTurnTaker(
-        bytes calldata encodedState,
+        bytes calldata /* encodedState */,
         address[] calldata participants
     )
+        override
         external
         view
         returns (address)
@@ -86,6 +89,7 @@ contract SimpleSignedTransferApp is CounterfactualApp {
     }
 
     function isStateTerminal(bytes calldata encodedState)
+        override
         external
         view
         returns (bool)

--- a/modules/contracts/contracts/apps/SimpleSignedTransferApp.sol
+++ b/modules/contracts/contracts/apps/SimpleSignedTransferApp.sol
@@ -28,6 +28,7 @@ contract SimpleSignedTransferApp is CounterfactualApp {
     }
 
     function init(bytes calldata encodedState)
+        override
         external
         view
         returns(bool)

--- a/modules/contracts/contracts/apps/SimpleTransferApp.sol
+++ b/modules/contracts/contracts/apps/SimpleTransferApp.sol
@@ -17,7 +17,8 @@ contract SimpleTransferApp is CounterfactualApp {
         LibOutcome.CoinTransfer[2] coinTransfers;
     }
 
-    function init(bytes calldata encodedState)
+    function init(bytes calldata /* encodedState */)
+        override
         external
         view
         returns(bool)

--- a/modules/contracts/contracts/apps/SimpleTransferApp.sol
+++ b/modules/contracts/contracts/apps/SimpleTransferApp.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.5.11;
+pragma solidity 0.6.7;
 pragma experimental "ABIEncoderV2";
 
 import "@openzeppelin/contracts/math/SafeMath.sol";
@@ -26,6 +26,7 @@ contract SimpleTransferApp is CounterfactualApp {
     }
 
     function computeOutcome(bytes calldata encodedState)
+        override
         external
         view
         returns (bytes memory)

--- a/modules/contracts/contracts/apps/SimpleTwoPartySwapApp.sol
+++ b/modules/contracts/contracts/apps/SimpleTwoPartySwapApp.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.5.11;
+pragma solidity 0.6.7;
 pragma experimental "ABIEncoderV2";
 
 import "@openzeppelin/contracts/math/SafeMath.sol";
@@ -25,6 +25,7 @@ contract SimpleTwoPartySwapApp is CounterfactualApp {
     }
 
     function computeOutcome(bytes calldata encodedState)
+        override
         external
         view
         returns (bytes memory)

--- a/modules/contracts/contracts/apps/SimpleTwoPartySwapApp.sol
+++ b/modules/contracts/contracts/apps/SimpleTwoPartySwapApp.sol
@@ -16,7 +16,8 @@ contract SimpleTwoPartySwapApp is CounterfactualApp {
         LibOutcome.CoinTransfer[][] coinTransfers;
     }
 
-    function init(bytes calldata encodedState)
+    function init(bytes calldata /* encodedState */)
+        override
         external
         view
         returns(bool)

--- a/modules/contracts/contracts/apps/TicTacToeApp.sol
+++ b/modules/contracts/contracts/apps/TicTacToeApp.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.5.11;
+pragma solidity 0.6.7;
 pragma experimental "ABIEncoderV2";
 
 import "../adjudicator/interfaces/CounterfactualApp.sol";
@@ -59,6 +59,7 @@ contract TicTacToeApp is CounterfactualApp {
     }
 
     function isStateTerminal(bytes calldata encodedState)
+        override
         external
         view
         returns (bool)
@@ -72,6 +73,7 @@ contract TicTacToeApp is CounterfactualApp {
         bytes calldata encodedState,
         address[] calldata participants
     )
+        override
         external
         view
         returns (address)
@@ -83,6 +85,7 @@ contract TicTacToeApp is CounterfactualApp {
     function applyAction(
         bytes calldata encodedState, bytes calldata encodedAction
     )
+        override
         external
         view
         returns (bytes memory)
@@ -128,6 +131,7 @@ contract TicTacToeApp is CounterfactualApp {
     }
 
     function computeOutcome(bytes calldata encodedState)
+      override
       external
       view
       returns (bytes memory)
@@ -156,7 +160,7 @@ contract TicTacToeApp is CounterfactualApp {
         uint256 y
     )
         internal
-        view
+        pure
         returns (AppState memory)
     {
         require(state.board[x][y] == 0, "playMove: square is not empty");
@@ -171,7 +175,7 @@ contract TicTacToeApp is CounterfactualApp {
 
     function assertBoardIsFull(AppState memory preState)
         internal
-        view
+        pure
     {
         for (uint256 i = 0; i < 3; i++) {
             for (uint256 j = 0; j < 3; j++) {
@@ -188,7 +192,7 @@ contract TicTacToeApp is CounterfactualApp {
         WinClaim memory winClaim
     )
         internal
-        view
+        pure
     {
         uint256 expectedSquareState = playerId + 1;
         if (winClaim.winClaimType == WinClaimType.COL) {

--- a/modules/contracts/contracts/apps/TicTacToeApp.sol
+++ b/modules/contracts/contracts/apps/TicTacToeApp.sol
@@ -50,10 +50,11 @@ contract TicTacToeApp is CounterfactualApp {
         WinClaim winClaim;
     }
 
-    function init(bytes calldata encodedState)
+    function init(bytes calldata /* encodedState */)
+        override
         external
         view
-        returns (bool) 
+        returns (bool)
     {
         return true;
     }

--- a/modules/contracts/contracts/apps/UnidirectionalLinkedTransferApp.sol
+++ b/modules/contracts/contracts/apps/UnidirectionalLinkedTransferApp.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.5.11;
+pragma solidity 0.6.7;
 pragma experimental "ABIEncoderV2";
 
 import "@openzeppelin/contracts/math/SafeMath.sol";
@@ -68,6 +68,7 @@ contract UnidirectionalLinkedTransferApp is CounterfactualApp {
     }
 
     function computeOutcome(bytes calldata encodedState)
+        override
         external
         view
         returns (bytes memory)
@@ -79,6 +80,7 @@ contract UnidirectionalLinkedTransferApp is CounterfactualApp {
         bytes calldata encodedState,
         bytes calldata encodedAction
     )
+        override
         external
         view
         returns (bytes memory)
@@ -164,6 +166,7 @@ contract UnidirectionalLinkedTransferApp is CounterfactualApp {
         bytes calldata encodedState,
         address[] calldata participants
     )
+        override
         external
         view
         returns (address)
@@ -174,6 +177,7 @@ contract UnidirectionalLinkedTransferApp is CounterfactualApp {
     }
 
     function isStateTerminal(bytes calldata encodedState)
+        override
         external
         view
         returns (bool)

--- a/modules/contracts/contracts/apps/UnidirectionalTransferApp.sol
+++ b/modules/contracts/contracts/apps/UnidirectionalTransferApp.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.5.11;
+pragma solidity 0.6.7;
 pragma experimental "ABIEncoderV2";
 
 import "@openzeppelin/contracts/math/SafeMath.sol";
@@ -118,6 +118,7 @@ contract UnidirectionalTransferApp is CounterfactualApp {
         bytes calldata encodedState,
         address[] calldata participants
     )
+        override
         external
         view
         returns (address)
@@ -128,6 +129,7 @@ contract UnidirectionalTransferApp is CounterfactualApp {
     }
 
     function computeOutcome(bytes calldata encodedState)
+        override
         external
         view
         returns (
@@ -141,6 +143,7 @@ contract UnidirectionalTransferApp is CounterfactualApp {
         bytes calldata encodedState,
         bytes calldata encodedAction
     )
+        override
         external
         view
         returns (bytes memory)
@@ -208,6 +211,7 @@ contract UnidirectionalTransferApp is CounterfactualApp {
     }
 
     function isStateTerminal(bytes calldata encodedState)
+        override
         external
         view
         returns (bool)

--- a/modules/contracts/contracts/funding/ConditionalTransactionDelegateTarget.sol
+++ b/modules/contracts/contracts/funding/ConditionalTransactionDelegateTarget.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.5.11;
+pragma solidity 0.6.7;
 pragma experimental "ABIEncoderV2";
 
 import "./state-deposit-holders/MultisigTransfer.sol";
@@ -30,7 +30,7 @@ contract ConditionalTransactionDelegateTarget is MultisigTransfer {
         address payable recipient,
         address assetId,
         uint256 amount,
-        bytes32 nonce
+        bytes32 /* nonce */
     )
         public
     {
@@ -61,11 +61,7 @@ contract ConditionalTransactionDelegateTarget is MultisigTransfer {
             limits[i] = MAX_UINT256;
         }
 
-        (
-            bool success,
-            // solium-disable-next-line no-unused-vars
-            bytes memory returnData
-        ) = multiAssetMultiPartyCoinTransferInterpreterAddress.delegatecall(
+        (bool success, ) = multiAssetMultiPartyCoinTransferInterpreterAddress.delegatecall(
             abi.encodeWithSignature(
                 "interpretOutcomeAndExecuteEffect(bytes,bytes)",
                 abi.encode(freeBalanceAppState.balances),
@@ -112,11 +108,7 @@ contract ConditionalTransactionDelegateTarget is MultisigTransfer {
 
         bytes memory outcome = challengeRegistry.getOutcome(appIdentityHash);
 
-        (
-            bool success,
-            // solium-disable-next-line no-unused-vars
-            bytes memory returnData
-        ) = interpreterAddress.delegatecall(
+        (bool success, ) = interpreterAddress.delegatecall(
             abi.encodeWithSignature(
                 "interpretOutcomeAndExecuteEffect(bytes,bytes)",
                 outcome,

--- a/modules/contracts/contracts/funding/Interpreter.sol
+++ b/modules/contracts/contracts/funding/Interpreter.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.5.11;
+pragma solidity 0.6.7;
 pragma experimental "ABIEncoderV2";
 
 

--- a/modules/contracts/contracts/funding/default-apps/DepositApp.sol
+++ b/modules/contracts/contracts/funding/default-apps/DepositApp.sol
@@ -26,6 +26,7 @@ contract DepositApp is CounterfactualApp {
     }
 
     function init(bytes calldata encodedState)
+        override
         external
         view
         returns (bool)
@@ -38,7 +39,7 @@ contract DepositApp is CounterfactualApp {
         uint256 startingTotalAmountWithdrawn;
         uint256 startingMultisigBalance;
 
-        if (isDeployed(state.multisigAddress)) {
+        if (Address.isContract(state.multisigAddress)) {
             startingTotalAmountWithdrawn = MinimumViableMultisig(state.multisigAddress).totalAmountWithdrawn(state.assetId);
         } else {
             startingTotalAmountWithdrawn = 0;
@@ -47,7 +48,7 @@ contract DepositApp is CounterfactualApp {
         if (state.assetId == CONVENTION_FOR_ETH_TOKEN_ADDRESS) {
             startingMultisigBalance = state.multisigAddress.balance;
         } else {
-            startingMultisigBalance = ERC20(state.assetId).balanceOf(state.multisigAddress);
+            startingMultisigBalance = IERC20(state.assetId).balanceOf(state.multisigAddress);
         }
 
         require(

--- a/modules/contracts/contracts/funding/default-apps/DepositApp.sol
+++ b/modules/contracts/contracts/funding/default-apps/DepositApp.sol
@@ -1,7 +1,8 @@
-pragma solidity 0.5.11;
+pragma solidity 0.6.7;
 pragma experimental "ABIEncoderV2";
 
-import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import "@openzeppelin/contracts/utils/Address.sol";
 import "../../adjudicator/interfaces/CounterfactualApp.sol";
 import "../state-deposit-holders/MinimumViableMultisig.sol";
 import "../libs/LibOutcome.sol";
@@ -63,6 +64,7 @@ contract DepositApp is CounterfactualApp {
     }
 
     function computeOutcome(bytes calldata encodedState)
+        override
         external
         view
         returns (bytes memory)
@@ -72,7 +74,7 @@ contract DepositApp is CounterfactualApp {
         uint256 endingTotalAmountWithdrawn;
         uint256 endingMultisigBalance;
 
-        if (isDeployed(state.multisigAddress)) {
+        if (Address.isContract(state.multisigAddress)) {
             endingTotalAmountWithdrawn = MinimumViableMultisig(state.multisigAddress).totalAmountWithdrawn(state.assetId);
         } else {
             endingTotalAmountWithdrawn = 0;
@@ -81,7 +83,7 @@ contract DepositApp is CounterfactualApp {
         if (state.assetId == CONVENTION_FOR_ETH_TOKEN_ADDRESS) {
             endingMultisigBalance = state.multisigAddress.balance;
         } else {
-            endingMultisigBalance = ERC20(state.assetId).balanceOf(state.multisigAddress);
+            endingMultisigBalance = IERC20(state.assetId).balanceOf(state.multisigAddress);
         }
 
         return abi.encode(LibOutcome.CoinTransfer[2]([
@@ -99,15 +101,4 @@ contract DepositApp is CounterfactualApp {
         ]));
     }
 
-    function isDeployed(address _addr)
-        internal
-        view
-    returns (bool)
-    {
-        uint32 size;
-        assembly {
-            size := extcodesize(_addr)
-        }
-        return (size > 0);
-    }
 }

--- a/modules/contracts/contracts/funding/default-apps/FinalizedApp.sol
+++ b/modules/contracts/contracts/funding/default-apps/FinalizedApp.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.5.11;
+pragma solidity 0.6.7;
 pragma experimental "ABIEncoderV2";
 
 import "./IdentityApp.sol";
@@ -7,6 +7,7 @@ import "./IdentityApp.sol";
 contract FinalizedApp is IdentityApp {
 
     function isStateTerminal(bytes calldata)
+        override
         external
         view
         returns (bool)

--- a/modules/contracts/contracts/funding/default-apps/IdentityApp.sol
+++ b/modules/contracts/contracts/funding/default-apps/IdentityApp.sol
@@ -6,7 +6,8 @@ import "../../adjudicator/interfaces/CounterfactualApp.sol";
 
 contract IdentityApp is CounterfactualApp {
 
-    function init(bytes calldata encodedState)
+    function init(bytes calldata /* encodedState */)
+        override
         external
         view
         returns(bool)

--- a/modules/contracts/contracts/funding/default-apps/IdentityApp.sol
+++ b/modules/contracts/contracts/funding/default-apps/IdentityApp.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.5.11;
+pragma solidity 0.6.7;
 pragma experimental "ABIEncoderV2";
 
 import "../../adjudicator/interfaces/CounterfactualApp.sol";
@@ -15,6 +15,8 @@ contract IdentityApp is CounterfactualApp {
     }
 
     function computeOutcome(bytes calldata encodedState)
+        override
+        virtual
         external
         view
         returns (bytes memory)

--- a/modules/contracts/contracts/funding/default-apps/TimeLockedPassthrough.sol
+++ b/modules/contracts/contracts/funding/default-apps/TimeLockedPassthrough.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.5.11;
+pragma solidity 0.6.7;
 pragma experimental "ABIEncoderV2";
 
 import "../../adjudicator/ChallengeRegistry.sol";

--- a/modules/contracts/contracts/funding/default-apps/WithdrawApp.sol
+++ b/modules/contracts/contracts/funding/default-apps/WithdrawApp.sol
@@ -56,6 +56,7 @@ contract WithdrawApp is CounterfactualApp {
     function init(
         bytes calldata encodedState
     )
+        override
         external
         view
         returns(bool)

--- a/modules/contracts/contracts/funding/default-apps/WithdrawApp.sol
+++ b/modules/contracts/contracts/funding/default-apps/WithdrawApp.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.5.11;
+pragma solidity 0.6.7;
 pragma experimental "ABIEncoderV2";
 
 import "../../shared/libs/LibChannelCrypto.sol";
@@ -31,6 +31,7 @@ contract WithdrawApp is CounterfactualApp {
     }
 
     function isStateTerminal(bytes calldata encodedState)
+        override
         external
         view
         returns (bool)
@@ -41,8 +42,9 @@ contract WithdrawApp is CounterfactualApp {
 
     function getTurnTaker(
         bytes calldata encodedState,
-        address[] calldata participants
+        address[] calldata /* participants */
     )
+        override
         external
         view
         returns (address)
@@ -82,6 +84,7 @@ contract WithdrawApp is CounterfactualApp {
         bytes calldata encodedState,
         bytes calldata encodedAction
     )
+        override
         external
         view
         returns (bytes memory)
@@ -100,6 +103,7 @@ contract WithdrawApp is CounterfactualApp {
     }
 
     function computeOutcome(bytes calldata encodedState)
+        override
         external
         view
         returns (bytes memory)

--- a/modules/contracts/contracts/funding/interpreters/MultiAssetMultiPartyCoinTransferInterpreter.sol
+++ b/modules/contracts/contracts/funding/interpreters/MultiAssetMultiPartyCoinTransferInterpreter.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.5.11;
+pragma solidity 0.6.7;
 pragma experimental "ABIEncoderV2";
 
 import "../state-deposit-holders/MultisigTransfer.sol";
@@ -18,12 +18,13 @@ contract MultiAssetMultiPartyCoinTransferInterpreter is MultisigTransfer, Interp
     // NOTE: This is useful for writing tests, but is bad practice
     // to have in the contract when deploying it. We do not want people
     // to send funds to this contract in any scenario.
-    function () external payable { }
+    receive() external payable { }
 
     function interpretOutcomeAndExecuteEffect(
         bytes calldata encodedOutcome,
         bytes calldata encodedParams
     )
+        override
         external
     {
         MultiAssetMultiPartyCoinTransferInterpreterParams memory params = abi.decode(

--- a/modules/contracts/contracts/funding/interpreters/SingleAssetTwoPartyCoinTransferInterpreter.sol
+++ b/modules/contracts/contracts/funding/interpreters/SingleAssetTwoPartyCoinTransferInterpreter.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.5.11;
+pragma solidity 0.6.7;
 pragma experimental "ABIEncoderV2";
 
 import "../state-deposit-holders/MultisigTransfer.sol";
@@ -19,12 +19,13 @@ contract SingleAssetTwoPartyCoinTransferInterpreter is MultisigTransfer, Interpr
     // NOTE: This is useful for writing tests, but is bad practice
     // to have in the contract when deploying it. We do not want people
     // to send funds to this contract in any scenario.
-    function () external payable { }
+    receive() external payable { }
 
     function interpretOutcomeAndExecuteEffect(
         bytes calldata encodedOutput,
         bytes calldata encodedParams
     )
+        override
         external
     {
         Params memory params = abi.decode(encodedParams, (Params));

--- a/modules/contracts/contracts/funding/interpreters/TwoPartyFixedOutcomeInterpreter.sol
+++ b/modules/contracts/contracts/funding/interpreters/TwoPartyFixedOutcomeInterpreter.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.5.11;
+pragma solidity 0.6.7;
 pragma experimental "ABIEncoderV2";
 
 import "../state-deposit-holders/MultisigTransfer.sol";
@@ -23,6 +23,7 @@ contract TwoPartyFixedOutcomeInterpreter is MultisigTransfer, Interpreter {
         bytes calldata encodedOutcome,
         bytes calldata encodedParams
     )
+        override
         external
     {
         LibOutcome.TwoPartyFixedOutcome outcome = abi.decode(

--- a/modules/contracts/contracts/funding/libs/LibOutcome.sol
+++ b/modules/contracts/contracts/funding/libs/LibOutcome.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.5.11;
+pragma solidity 0.6.7;
 pragma experimental "ABIEncoderV2";
 
 

--- a/modules/contracts/contracts/funding/proxies/Proxy.sol
+++ b/modules/contracts/contracts/funding/proxies/Proxy.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.5.11;
+pragma solidity 0.6.7;
 
 
 /// @title Proxy - Generic proxy contract allows to execute all transactions applying the code of a master contract.
@@ -20,15 +20,15 @@ contract Proxy {
     }
 
     /// @dev Fallback function forwards all transactions and returns all received return data.
-    function ()
+    fallback()
         external
         payable
     {
         // solium-disable-next-line security/no-inline-assembly
         assembly {
-            let masterCopy := and(sload(0), 0xffffffffffffffffffffffffffffffffffffffff)
+            let _masterCopy := and(sload(0), 0xffffffffffffffffffffffffffffffffffffffff)
             calldatacopy(0, 0, calldatasize())
-            let success := delegatecall(gas, masterCopy, 0, calldatasize(), 0, 0)
+            let success := delegatecall(gas(), _masterCopy, 0, calldatasize(), 0, 0)
             returndatacopy(0, 0, returndatasize())
             if eq(success, 0) { revert(0, returndatasize()) }
             return(0, returndatasize())

--- a/modules/contracts/contracts/funding/proxies/ProxyFactory.sol
+++ b/modules/contracts/contracts/funding/proxies/ProxyFactory.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.5.11;
+pragma solidity 0.6.7;
 
 import "./Proxy.sol";
 
@@ -38,7 +38,7 @@ contract ProxyFactory {
         if (data.length > 0) {
             // solium-disable-next-line security/no-inline-assembly
             assembly {
-              if eq(call(gas, proxy, 0, add(data, 0x20), mload(data), 0, 0), 0) { revert(0, 0) }
+              if eq(call(gas(), proxy, 0, add(data, 0x20), mload(data), 0, 0), 0) { revert(0, 0) }
             }
         }
         emit ProxyCreation(proxy);
@@ -70,7 +70,7 @@ contract ProxyFactory {
         if (initializer.length > 0) {
             // solium-disable-next-line security/no-inline-assembly
             assembly {
-                if eq(call(gas, proxy, 0, add(initializer, 0x20), mload(initializer), 0, 0), 0) { revert(0,0) }
+                if eq(call(gas(), proxy, 0, add(initializer, 0x20), mload(initializer), 0, 0), 0) { revert(0,0) }
             }
         }
         emit ProxyCreation(proxy);

--- a/modules/contracts/contracts/funding/state-deposit-holders/MinimumViableMultisig.sol
+++ b/modules/contracts/contracts/funding/state-deposit-holders/MinimumViableMultisig.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.5.11;
+pragma solidity 0.6.7;
 pragma experimental ABIEncoderV2;
 
 import "./MultisigData.sol";
@@ -27,10 +27,7 @@ contract MinimumViableMultisig is MultisigData, LibCommitment {
         DelegateCall
     }
 
-    function ()
-        external
-        payable
-    {}
+    receive() external payable { }
 
     /// @notice Contract constructor
     /// @param owners An array of unique addresses representing the multisig owners
@@ -138,7 +135,7 @@ contract MinimumViableMultisig is MultisigData, LibCommitment {
     }
 
     /// @notice Execute a CALL on behalf of the multisignature wallet
-    /// @return A boolean indicating if the transaction was successful or not
+    /// @return success A boolean indicating if the transaction was successful or not
     function executeCall(address to, uint256 value, bytes memory data)
         internal
         returns (bool success)
@@ -149,7 +146,7 @@ contract MinimumViableMultisig is MultisigData, LibCommitment {
     }
 
     /// @notice Execute a DELEGATECALL on behalf of the multisignature wallet
-    /// @return A boolean indicating if the transaction was successful or not
+    /// @return success A boolean indicating if the transaction was successful or not
     function executeDelegateCall(address to, bytes memory data)
         internal
         returns (bool success)

--- a/modules/contracts/contracts/funding/state-deposit-holders/MultisigData.sol
+++ b/modules/contracts/contracts/funding/state-deposit-holders/MultisigData.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.5.11;
+pragma solidity 0.6.7;
 pragma experimental ABIEncoderV2;
 
 

--- a/modules/contracts/contracts/funding/state-deposit-holders/MultisigTransfer.sol
+++ b/modules/contracts/contracts/funding/state-deposit-holders/MultisigTransfer.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.5.11;
+pragma solidity 0.6.7;
 pragma experimental ABIEncoderV2;
 
 import "./MultisigData.sol";

--- a/modules/contracts/contracts/funding/test-fixtures/DelegateProxy.sol
+++ b/modules/contracts/contracts/funding/test-fixtures/DelegateProxy.sol
@@ -1,9 +1,9 @@
-pragma solidity 0.5.11;
+pragma solidity 0.6.7;
 
-import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 
 contract DelegateProxy {
-    function () external payable { }
+    receive() external payable { }
 
     mapping(address => uint256) public totalAmountWithdrawn;
     address constant CONVENTION_FOR_ETH_TOKEN_ADDRESS = address(0x0);
@@ -19,7 +19,7 @@ contract DelegateProxy {
         if (assetId == CONVENTION_FOR_ETH_TOKEN_ADDRESS) {
             recipient.send(amount);
         } else {
-            ERC20(assetId).transfer(recipient, amount);
+            IERC20(assetId).transfer(recipient, amount);
         }
     }
 }

--- a/modules/contracts/contracts/funding/test-fixtures/DolphinCoin.sol
+++ b/modules/contracts/contracts/funding/test-fixtures/DolphinCoin.sol
@@ -1,16 +1,17 @@
-pragma solidity 0.5.11;
+pragma solidity 0.6.7;
 
 import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 
 
-contract DolphinCoin is ERC20 {
+contract DolphinCoin is ERC20("DolphinCoin", "DOC") {
     uint8 public constant DECIMALS = 18;
-    uint256 public constant INITIAL_SUPPLY = 10000 * (10 ** uint256(DECIMALS));
+    uint256 public constant INITIAL_SUPPLY = 10_000 * (uint256(10) ** DECIMALS);
 
     /**
      * @dev Constructor that gives msg.sender all of existing tokens.
      */
     constructor() public {
+        _setupDecimals(DECIMALS);
         _mint(msg.sender, INITIAL_SUPPLY);
     }
 }

--- a/modules/contracts/contracts/funding/test-fixtures/Echo.sol
+++ b/modules/contracts/contracts/funding/test-fixtures/Echo.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.5.11;
+pragma solidity 0.6.7;
 
 
 contract Echo {

--- a/modules/contracts/contracts/funding/test-fixtures/FixedTwoPartyOutcomeApp.sol
+++ b/modules/contracts/contracts/funding/test-fixtures/FixedTwoPartyOutcomeApp.sol
@@ -1,12 +1,14 @@
-pragma solidity 0.5.11;
+pragma solidity 0.6.7;
 pragma experimental "ABIEncoderV2";
 
+import "../../adjudicator/interfaces/CounterfactualApp.sol";
 import "../libs/LibOutcome.sol";
 
 
-contract TwoPartyFixedOutcomeApp {
+contract TwoPartyFixedOutcomeApp is CounterfactualApp {
 
-    function computeOutcome(bytes calldata)
+    function computeOutcome(bytes calldata /* encodedState */)
+        override
         external
         view
         returns (bytes memory)

--- a/modules/contracts/contracts/shared/libs/LibChannelCrypto.sol
+++ b/modules/contracts/contracts/shared/libs/LibChannelCrypto.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.5.11;
+pragma solidity 0.6.7;
 pragma experimental ABIEncoderV2;
 
 import "@openzeppelin/contracts/cryptography/ECDSA.sol";

--- a/modules/contracts/contracts/shared/libs/LibCommitment.sol
+++ b/modules/contracts/contracts/shared/libs/LibCommitment.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.5.11;
+pragma solidity 0.6.7;
 pragma experimental ABIEncoderV2;
 
 

--- a/modules/contracts/package.json
+++ b/modules/contracts/package.json
@@ -32,7 +32,7 @@
     "@connext/utils": "6.3.13",
     "@connext/types": "6.3.13",
     "ethers": "4.0.47",
-    "@openzeppelin/contracts": "2.5.0",
+    "@openzeppelin/contracts": "3.0.1",
     "ganache-cli": "6.9.1",
     "solc": "0.5.11",
     "eventemitter3": "4.0.0"

--- a/modules/contracts/test/funding/withdraw-app.spec.ts
+++ b/modules/contracts/test/funding/withdraw-app.spec.ts
@@ -42,10 +42,12 @@ describe("WithdrawApp", async () => {
   // test constants
   const withdrawerWallet = Wallet.createRandom();
   const counterpartyWallet = Wallet.createRandom();
+  const bystanderWallet = Wallet.createRandom();
   const amount = new BigNumber(10000);
   const data = mkHash("0xa"); // TODO: test this with real withdrawal commitment hash?
   const withdrawerSigningKey = new SigningKey(withdrawerWallet.privateKey);
   const counterpartySigningKey = new SigningKey(counterpartyWallet.privateKey);
+  const bystanderSigningKey = new SigningKey(bystanderWallet.privateKey);
 
   before(async () => {
     wallet = (await provider.getWallets())[2];
@@ -179,7 +181,7 @@ describe("WithdrawApp", async () => {
     let initialState = await createInitialState();
     let action = await createAction();
 
-    initialState.signatures[0] = mkHash("0x0");
+    initialState.signatures[0] = await (new ChannelSigner(bystanderSigningKey.privateKey).signMessage(data));
     await expect(applyAction(initialState, action)).revertedWith("invalid withdrawer signature");
   });
 
@@ -187,7 +189,7 @@ describe("WithdrawApp", async () => {
     let initialState = await createInitialState();
     let action = await createAction();
 
-    action.signature = HashZero;
+    action.signature = await (new ChannelSigner(bystanderSigningKey.privateKey).signMessage(data));
     await expect(applyAction(initialState, action)).revertedWith("invalid counterparty signature");
   });
 });

--- a/modules/contracts/test/funding/withdraw-app.spec.ts
+++ b/modules/contracts/test/funding/withdraw-app.spec.ts
@@ -128,7 +128,7 @@ describe("WithdrawApp", async () => {
 
   it("fails init with incorrect withdrawer signature", async() => {
     let initialState = await createInitialState();
-    initialState.signatures[0] = "0x0100000000000000000000000000000000000000000000000000000000000000";
+    initialState.signatures[0] = await new ChannelSigner(bystanderSigningKey.privateKey).signMessage(data);
     await expect(init(initialState)).revertedWith("cannot install withdraw app with invalid withdrawer signature");
   })
 

--- a/modules/contracts/test/funding/withdraw-app.spec.ts
+++ b/modules/contracts/test/funding/withdraw-app.spec.ts
@@ -181,7 +181,7 @@ describe("WithdrawApp", async () => {
     let initialState = await createInitialState();
     let action = await createAction();
 
-    initialState.signatures[0] = await (new ChannelSigner(bystanderSigningKey.privateKey).signMessage(data));
+    initialState.signatures[0] = await new ChannelSigner(bystanderSigningKey.privateKey).signMessage(data);
     await expect(applyAction(initialState, action)).revertedWith("invalid withdrawer signature");
   });
 
@@ -189,7 +189,7 @@ describe("WithdrawApp", async () => {
     let initialState = await createInitialState();
     let action = await createAction();
 
-    action.signature = await (new ChannelSigner(bystanderSigningKey.privateKey).signMessage(data));
+    action.signature = await new ChannelSigner(bystanderSigningKey.privateKey).signMessage(data);
     await expect(applyAction(initialState, action)).revertedWith("invalid counterparty signature");
   });
 });

--- a/modules/node/package.json
+++ b/modules/node/package.json
@@ -34,7 +34,7 @@
     "@nestjs/microservices": "7.0.8",
     "@nestjs/platform-express": "7.0.8",
     "@nestjs/typeorm": "7.0.0",
-    "@openzeppelin/contracts": "2.5.0",
+    "@openzeppelin/contracts": "3.0.1",
     "@uniswap/sdk": "1.0.0-beta.4",
     "bs58check": "2.1.2",
     "class-validator": "0.12.1",

--- a/modules/test-runner/package.json
+++ b/modules/test-runner/package.json
@@ -22,7 +22,7 @@
     "@connext/store": "6.3.13",
     "@connext/types": "6.3.13",
     "@ethereum-waffle/chai": "2.4.1",
-    "@openzeppelin/contracts": "2.5.0",
+    "@openzeppelin/contracts": "3.0.1",
     "axios": "0.19.2",
     "bs58check": "2.1.2",
     "chai": "4.2.0",

--- a/modules/watcher/test/utils/contracts.ts
+++ b/modules/watcher/test/utils/contracts.ts
@@ -79,7 +79,7 @@ export const deployTestArtifactsToChain = async (
     ERC20.abi,
     ERC20.bytecode,
     wallet,
-  ).deploy();
+  ).deploy("", "");
 
   const appWithCounter = await new ContractFactory(
     AppWithAction.abi,

--- a/package-lock.json
+++ b/package-lock.json
@@ -4973,9 +4973,9 @@
 			}
 		},
 		"@openzeppelin/contracts": {
-			"version": "2.5.0",
-			"resolved": "https://registry.npmjs.org/@openzeppelin/contracts/-/contracts-2.5.0.tgz",
-			"integrity": "sha512-t3jm8FrhL9tkkJTofkznTqo/XXdHi21w5yXwalEnaMOp22ZwZ0f/mmKdlgMMLPFa6bSVHbY88mKESwJT/7m5Lg==",
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/@openzeppelin/contracts/-/contracts-3.0.1.tgz",
+			"integrity": "sha512-uSrD7hZ0ViuHGqHZbeHawZBi/uy7aBiNramXAt2dFFuSuoU4u9insS3V3zdVfOnYSPreUo636xSOuQIFN4//HA==",
 			"dev": true
 		},
 		"@provide/nats.ws": {

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "lint": "bash ops/lint.sh"
   },
   "devDependencies": {
-    "@openzeppelin/contracts": "2.5.0",
+    "@openzeppelin/contracts": "3.0.1",
     "@typescript-eslint/eslint-plugin": "2.29.0",
     "@typescript-eslint/parser": "2.29.0",
     "bn.js": "5.1.1",


### PR DESCRIPTION
Port the changes in the contracts and tests that were made for the upgrade to Solidity v0.6 and OpenZeppelin v3.0 to the init validation WIP.