### PR TITLE
chore: add local address book to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,6 @@ ops/database/snapshots
 ganache.http
 modules/bot/.connext-store/
 modules/bot-registry/.node-persist/
+
+# Local address book
+address-book.json


### PR DESCRIPTION
This commit adds `address-book.json` that is located in the project root
to the .gitignore

This is to ensure users can pull updates to the rest of the code without worrying about your addresses getting overwritten.