### PR TITLE
1347 withdraw tx

### DIFF
--- a/modules/cf-core/src/cfCore.ts
+++ b/modules/cf-core/src/cfCore.ts
@@ -204,8 +204,8 @@ export class CFCore {
 
     protocolRunner.register(
       Opcode.IO_SEND,
-      async (args: [ProtocolMessageData, StateChannel, AppInstance]) => {
-        const [data, channel, appContext] = args;
+      async (args: [ProtocolMessageData, StateChannel, AppInstance, any]) => {
+        const [data, channel, appContext, protocolMeta] = args;
 
         // check if the protocol start time exists within the message
         // and if it is a final protocol message (see note in
@@ -228,7 +228,7 @@ export class CFCore {
           type: EventNames.PROTOCOL_MESSAGE_EVENT,
         });
 
-        return { channel, appContext };
+        return { channel, appContext, protocolMeta };
       },
     );
 

--- a/modules/cf-core/src/machine/protocol-runner.ts
+++ b/modules/cf-core/src/machine/protocol-runner.ts
@@ -134,7 +134,7 @@ export class ProtocolRunner {
     instruction: (context: Context) => AsyncIterableIterator<any>,
     message: ProtocolMessage,
     preProtocolStateChannel?: StateChannel,
-  ): Promise<{ channel: StateChannel; data: any; appContext: AppInstance }> {
+  ): Promise<{ channel: StateChannel; data: any; appContext: AppInstance; protocolMeta: any }> {
     const context: Context = {
       log: this.log,
       message,

--- a/modules/cf-core/src/methods/app-instance/uninstall.ts
+++ b/modules/cf-core/src/methods/app-instance/uninstall.ts
@@ -152,6 +152,7 @@ export async function uninstallAppInstanceFromChannel(
       appIdentityHash: appInstance.identityHash,
       action: params.action,
       stateTimeout: toBN(0), // Explicitly finalized states
+      protocolMeta: params.protocolMeta,
     },
     preProtocolStateChannel,
   );

--- a/modules/cf-core/src/protocol/uninstall.ts
+++ b/modules/cf-core/src/protocol/uninstall.ts
@@ -44,6 +44,7 @@ export const UNINSTALL_PROTOCOL: ProtocolExecutionFlow = {
       action,
       stateTimeout,
       initiatorIdentifier,
+      protocolMeta,
     } = params as ProtocolParams.Uninstall;
 
     if (!preProtocolStateChannel) {
@@ -127,7 +128,7 @@ export const UNINSTALL_PROTOCOL: ProtocolExecutionFlow = {
       IO_SEND_AND_WAIT,
       generateProtocolMessageData(responderIdentifier, protocol, processID, 1, params!, {
         prevMessageReceived: start,
-        customData: { signature: mySignature },
+        customData: { signature: mySignature, protocolMeta },
       }),
     ];
     const {
@@ -169,7 +170,7 @@ export const UNINSTALL_PROTOCOL: ProtocolExecutionFlow = {
     const log = context.log.newContext("CF-UninstallProtocol");
     const start = Date.now();
     let substart = start;
-    const { params, processID } = message.data;
+    const { params, processID, customData } = message.data;
     const loggerId = (params as ProtocolParams.Uninstall).appIdentityHash || processID;
     log.info(`[${loggerId}] Response started`);
     log.debug(`[${loggerId}] Protocol response started with params ${stringify(params)}`);
@@ -251,7 +252,7 @@ export const UNINSTALL_PROTOCOL: ProtocolExecutionFlow = {
       postProtocolStateChannel.freeBalance,
     );
 
-    const counterpartySignature = context.message.data.customData.signature;
+    const counterpartySignature = customData.signature;
     const uninstallCommitmentHash = uninstallCommitment.hashToSign();
 
     // 15ms
@@ -299,6 +300,7 @@ export const UNINSTALL_PROTOCOL: ProtocolExecutionFlow = {
       ),
       postProtocolStateChannel,
       preUninstallApp,
+      customData?.protocolMeta,
     ];
 
     // 100ms

--- a/modules/cf-core/src/testing/scenarios/sync.spec.ts
+++ b/modules/cf-core/src/testing/scenarios/sync.spec.ts
@@ -151,13 +151,13 @@ describe("Sync", () => {
       await (newNodeA as CFCore).rpcRouter.dispatch(
         constructInstallRpc(identityHash, multisigAddress),
       );
-      expect(syncedChannel).to.deep.eq(expectedChannel!);
+      expect(syncedChannel).to.containSubset(expectedChannel!);
       const newAppInstanceA = await storeServiceA.getAppInstance(identityHash);
       const newAppInstanceB = await storeServiceB.getAppInstance(identityHash);
       const newChannelA = await storeServiceA.getStateChannel(multisigAddress);
       const newChannelB = await storeServiceB.getStateChannel(multisigAddress);
-      expect(newChannelA!).to.deep.eq(newChannelB!);
-      expect(newAppInstanceA!).to.deep.eq(newAppInstanceB!);
+      expect(newChannelA!).to.containSubset(newChannelB!);
+      expect(newAppInstanceA!).to.containSubset(newAppInstanceB!);
       expect(newAppInstanceA!.identityHash).to.eq(identityHash);
       expect(newAppInstanceA!.appSeqNo).to.eq(2);
       expect(newAppInstanceA!.latestVersionNumber).to.eq(1);
@@ -191,7 +191,7 @@ describe("Sync", () => {
         type: EventNames.SYNC,
         data: { syncedChannel: bigNumberifyJson(expectedChannel) },
       });
-      expect(syncedChannel).to.deep.eq(expectedChannel!);
+      expect(syncedChannel).to.containSubset(expectedChannel!);
       await (newNodeB as CFCore).rpcRouter.dispatch(
         constructInstallRpc(identityHash, multisigAddress),
       );
@@ -199,8 +199,8 @@ describe("Sync", () => {
       const newAppInstanceB = await storeServiceB.getAppInstance(identityHash);
       const newChannelA = await storeServiceA.getStateChannel(multisigAddress);
       const newChannelB = await storeServiceB.getStateChannel(multisigAddress);
-      expect(newChannelA!).to.deep.eq(newChannelB!);
-      expect(newAppInstanceA!).to.deep.eq(newAppInstanceB!);
+      expect(newChannelA!).to.containSubset(newChannelB!);
+      expect(newAppInstanceA!).to.containSubset(newAppInstanceB!);
       expect(newAppInstanceB!.identityHash).to.eq(identityHash);
       expect(newAppInstanceB!.appSeqNo).to.eq(2);
       expect(newAppInstanceB!.latestVersionNumber).to.eq(1);
@@ -217,8 +217,8 @@ describe("Sync", () => {
       const newAppInstanceB = await storeServiceB.getAppInstance(identityHash);
       const newChannelA = await storeServiceA.getStateChannel(multisigAddress);
       const newChannelB = await storeServiceB.getStateChannel(multisigAddress);
-      expect(newChannelA!).to.deep.eq(newChannelB!);
-      expect(newAppInstanceA!).to.deep.eq(newAppInstanceB!);
+      expect(newChannelA!).to.containSubset(newChannelB!);
+      expect(newAppInstanceA!).to.containSubset(newAppInstanceB!);
       expect(newAppInstanceA!.identityHash).to.eq(identityHash);
       expect(newAppInstanceA!.appSeqNo).to.eq(2);
       expect(newAppInstanceA!.latestVersionNumber).to.eq(1);
@@ -234,8 +234,8 @@ describe("Sync", () => {
       const newAppInstanceB = await storeServiceB.getAppInstance(identityHash);
       const newChannelA = await storeServiceA.getStateChannel(multisigAddress);
       const newChannelB = await storeServiceB.getStateChannel(multisigAddress);
-      expect(newChannelA!).to.deep.eq(newChannelB!);
-      expect(newAppInstanceA!).to.deep.eq(newAppInstanceB!);
+      expect(newChannelA!).to.containSubset(newChannelB!);
+      expect(newAppInstanceA!).to.containSubset(newAppInstanceB!);
       expect(newAppInstanceB!.identityHash).to.eq(identityHash);
       expect(newAppInstanceB!.appSeqNo).to.eq(2);
       expect(newAppInstanceB!.latestVersionNumber).to.eq(1);
@@ -326,12 +326,12 @@ describe("Sync", () => {
       ]);
 
       const syncedChannel = await storeServiceA.getStateChannel(multisigAddress);
-      expect(bigNumberifyJson(eventData)).to.deep.eq({
+      expect(bigNumberifyJson(eventData)).to.containSubset({
         from: nodeA.publicIdentifier,
         type: EventNames.SYNC,
         data: { syncedChannel: bigNumberifyJson(expectedChannel) },
       });
-      expect(syncedChannel).to.deep.eq(expectedChannel!);
+      expect(syncedChannel).to.containSubset(expectedChannel!);
 
       const rpc = makeProposeCall(newNodeA as CFCore, TicTacToeApp, multisigAddress);
       const res: any = await new Promise(async (resolve) => {
@@ -350,8 +350,8 @@ describe("Sync", () => {
       const newAppInstanceB = await storeServiceB.getAppProposal(res.data.appInstanceId);
       const newChannelA = await storeServiceA.getStateChannel(multisigAddress);
       const newChannelB = await storeServiceB.getStateChannel(multisigAddress);
-      expect(newChannelA!).to.deep.eq(newChannelB!);
-      expect(newAppInstanceA!).to.deep.eq(newAppInstanceB!);
+      expect(newChannelA!).to.containSubset(newChannelB!);
+      expect(newAppInstanceA!).to.containSubset(newAppInstanceB!);
       expect(newAppInstanceB!.identityHash).to.eq(res.data.appInstanceId);
       expect(newAppInstanceB!.appSeqNo).to.eq(3);
       expect(newAppInstanceB!.latestVersionNumber).to.eq(1);
@@ -380,12 +380,12 @@ describe("Sync", () => {
       ]);
 
       const syncedChannel = await storeServiceA.getStateChannel(multisigAddress);
-      expect(bigNumberifyJson(eventData)).to.deep.eq({
+      expect(bigNumberifyJson(eventData)).to.containSubset({
         from: (newNodeB as CFCore).publicIdentifier,
         type: EventNames.SYNC,
         data: { syncedChannel: bigNumberifyJson(expectedChannel) },
       });
-      expect(syncedChannel).to.deep.eq(expectedChannel!);
+      expect(syncedChannel).to.containSubset(expectedChannel!);
 
       const rpc = makeProposeCall(nodeA, TicTacToeApp, multisigAddress);
       const res: any = await new Promise(async (resolve) => {
@@ -404,8 +404,8 @@ describe("Sync", () => {
       const newAppInstanceB = await storeServiceB.getAppProposal(res.data.appInstanceId);
       const newChannelA = await storeServiceA.getStateChannel(multisigAddress);
       const newChannelB = await storeServiceB.getStateChannel(multisigAddress);
-      expect(newChannelA!).to.deep.eq(newChannelB!);
-      expect(newAppInstanceA!).to.deep.eq(newAppInstanceB!);
+      expect(newChannelA!).to.containSubset(newChannelB!);
+      expect(newAppInstanceA!).to.containSubset(newAppInstanceB!);
       expect(newAppInstanceB!.identityHash).to.eq(res.data.appInstanceId);
       expect(newAppInstanceB!.appSeqNo).to.eq(3);
       expect(newAppInstanceB!.latestVersionNumber).to.eq(1);
@@ -433,8 +433,8 @@ describe("Sync", () => {
       const newAppInstanceB = await storeServiceB.getAppProposal(res.data.appInstanceId);
       const newChannelA = await storeServiceA.getStateChannel(multisigAddress);
       const newChannelB = await storeServiceB.getStateChannel(multisigAddress);
-      expect(newChannelA!).to.deep.eq(newChannelB!);
-      expect(newAppInstanceA!).to.deep.eq(newAppInstanceB!);
+      expect(newChannelA!).to.containSubset(newChannelB!);
+      expect(newAppInstanceA!).to.containSubset(newAppInstanceB!);
       expect(newAppInstanceB!.identityHash).to.eq(res.data.appInstanceId);
       expect(newAppInstanceB!.appSeqNo).to.eq(3);
       expect(newAppInstanceB!.latestVersionNumber).to.eq(1);
@@ -462,8 +462,8 @@ describe("Sync", () => {
       const newAppInstanceB = await storeServiceB.getAppProposal(res.data.appInstanceId);
       const newChannelA = await storeServiceA.getStateChannel(multisigAddress);
       const newChannelB = await storeServiceB.getStateChannel(multisigAddress);
-      expect(newChannelA!).to.deep.eq(newChannelB!);
-      expect(newAppInstanceA!).to.deep.eq(newAppInstanceB!);
+      expect(newChannelA!).to.containSubset(newChannelB!);
+      expect(newAppInstanceA!).to.containSubset(newAppInstanceB!);
       expect(newAppInstanceB!.identityHash).to.eq(res.data.appInstanceId);
       expect(newAppInstanceB!.appSeqNo).to.eq(3);
       expect(newAppInstanceB!.latestVersionNumber).to.eq(1);
@@ -542,7 +542,7 @@ describe("Sync", () => {
         type: EventNames.SYNC,
         data: { syncedChannel: expectedChannel },
       });
-      expect(syncedChannel).to.deep.eq(expectedChannel!);
+      expect(syncedChannel).to.containSubset(expectedChannel!);
 
       // propose new app
       await installApp(newNodeA, nodeB, multisigAddress, TicTacToeApp);
@@ -572,7 +572,7 @@ describe("Sync", () => {
         type: EventNames.SYNC,
         data: { syncedChannel: expectedChannel },
       });
-      expect(syncedChannel).to.deep.eq(expectedChannel!);
+      expect(syncedChannel).to.containSubset(expectedChannel!);
 
       // propose new app
       await installApp(newNodeB, nodeA, multisigAddress, TicTacToeApp);
@@ -669,17 +669,17 @@ describe("Sync", () => {
       ]);
 
       const syncedChannel = await storeServiceA.getStateChannel(multisigAddress);
-      expect(eventData).to.deep.eq({
+      expect(eventData).to.containSubset({
         from: nodeB.publicIdentifier,
         type: EventNames.SYNC,
         data: { syncedChannel: expectedChannel },
       });
-      expect(syncedChannel).to.deep.eq(expectedChannel!);
+      expect(syncedChannel).to.containSubset(expectedChannel!);
 
       await uninstallApp(newNodeB as CFCore, nodeA, appIdentityHash, multisigAddress);
       const newChannelA = await storeServiceA.getStateChannel(multisigAddress);
       const newChannelB = await storeServiceB.getStateChannel(multisigAddress);
-      expect(newChannelA!).to.deep.eq(newChannelB!);
+      expect(newChannelA!).to.containSubset(newChannelB!);
       expect(newChannelA!.appInstances.length).to.eq(0);
       expect(newChannelA!.freeBalanceAppInstance!.latestVersionNumber).to.eq(3);
       expect(newChannelA!.monotonicNumProposedApps).to.eq(2);
@@ -702,17 +702,17 @@ describe("Sync", () => {
       ]);
 
       const syncedChannel = await storeServiceA.getStateChannel(multisigAddress);
-      expect(eventData).to.deep.eq({
+      expect(eventData).to.containSubset({
         from: nodeA.publicIdentifier,
         type: EventNames.SYNC,
         data: { syncedChannel: expectedChannel },
       });
-      expect(syncedChannel).to.deep.eq(expectedChannel!);
+      expect(syncedChannel).to.containSubset(expectedChannel!);
 
       await uninstallApp(nodeB, newNodeA as CFCore, appIdentityHash, multisigAddress);
       const newChannelA = await storeServiceA.getStateChannel(multisigAddress);
       const newChannelB = await storeServiceB.getStateChannel(multisigAddress);
-      expect(newChannelA!).to.deep.eq(newChannelB!);
+      expect(newChannelA!).to.containSubset(newChannelB!);
       expect(newChannelB!.appInstances.length).to.eq(0);
       expect(newChannelB!.freeBalanceAppInstance!.latestVersionNumber).to.eq(3);
       expect(newChannelB!.monotonicNumProposedApps).to.eq(2);
@@ -726,7 +726,7 @@ describe("Sync", () => {
 
       const newChannelA = await storeServiceA.getStateChannel(multisigAddress);
       const newChannelB = await storeServiceB.getStateChannel(multisigAddress);
-      expect(newChannelA!).to.deep.eq(newChannelB!);
+      expect(newChannelA!).to.containSubset(newChannelB!);
       expect(newChannelA!.appInstances.length).to.eq(0);
       expect(newChannelA!.freeBalanceAppInstance!.latestVersionNumber).to.eq(3);
       expect(newChannelA!.monotonicNumProposedApps).to.eq(2);
@@ -818,17 +818,17 @@ describe("Sync", () => {
       ]);
 
       const syncedChannel = await storeServiceA.getStateChannel(multisigAddress);
-      expect(eventData).to.deep.eq({
+      expect(eventData).to.containSubset({
         from: nodeB.publicIdentifier,
         type: EventNames.SYNC,
         data: { syncedChannel: expectedChannel },
       });
-      expect(syncedChannel).to.deep.eq(expectedChannel!);
+      expect(syncedChannel).to.containSubset(expectedChannel!);
 
       await uninstallApp(newNodeB as CFCore, nodeA, appIdentityHash, multisigAddress);
       const newChannelA = await storeServiceA.getStateChannel(multisigAddress);
       const newChannelB = await storeServiceB.getStateChannel(multisigAddress);
-      expect(newChannelA!).to.deep.eq(newChannelB!);
+      expect(newChannelA!).to.containSubset(newChannelB!);
       expect(newChannelA!.appInstances.length).to.eq(0);
       expect(newChannelA!.freeBalanceAppInstance!.latestVersionNumber).to.eq(3);
       expect(newChannelA!.monotonicNumProposedApps).to.eq(2);
@@ -851,17 +851,17 @@ describe("Sync", () => {
       ]);
 
       const syncedChannel = await storeServiceA.getStateChannel(multisigAddress);
-      expect(eventData).to.deep.eq({
+      expect(eventData).to.containSubset({
         from: nodeA.publicIdentifier,
         type: EventNames.SYNC,
         data: { syncedChannel: expectedChannel },
       });
-      expect(syncedChannel).to.deep.eq(expectedChannel!);
+      expect(syncedChannel).to.containSubset(expectedChannel!);
 
       await uninstallApp(nodeB, newNodeA as CFCore, appIdentityHash, multisigAddress);
       const newChannelA = await storeServiceA.getStateChannel(multisigAddress);
       const newChannelB = await storeServiceB.getStateChannel(multisigAddress);
-      expect(newChannelA!).to.deep.eq(newChannelB!);
+      expect(newChannelA!).to.containSubset(newChannelB!);
       expect(newChannelB!.appInstances.length).to.eq(0);
       expect(newChannelB!.freeBalanceAppInstance!.latestVersionNumber).to.eq(3);
       expect(newChannelB!.monotonicNumProposedApps).to.eq(2);
@@ -875,7 +875,7 @@ describe("Sync", () => {
 
       const newChannelA = await storeServiceA.getStateChannel(multisigAddress);
       const newChannelB = await storeServiceB.getStateChannel(multisigAddress);
-      expect(newChannelA!).to.deep.eq(newChannelB!);
+      expect(newChannelA!).to.containSubset(newChannelB!);
       expect(newChannelA!.appInstances.length).to.eq(0);
       expect(newChannelA!.freeBalanceAppInstance!.latestVersionNumber).to.eq(3);
       expect(newChannelA!.monotonicNumProposedApps).to.eq(2);
@@ -946,12 +946,12 @@ describe("Sync", () => {
       ]);
 
       const syncedChannel = await storeServiceA.getStateChannel(multisigAddress);
-      expect(eventData).to.deep.eq({
+      expect(eventData).to.containSubset({
         from: nodeB.publicIdentifier,
         type: EventNames.SYNC,
         data: { syncedChannel: expectedChannel },
       });
-      expect(syncedChannel).to.deep.eq(expectedChannel!);
+      expect(syncedChannel).to.containSubset(expectedChannel!);
 
       // create new app
       [identityHash] = await installApp(newNodeB as CFCore, nodeA, multisigAddress, TicTacToeApp);
@@ -963,8 +963,8 @@ describe("Sync", () => {
         storeServiceA.getStateChannel(multisigAddress),
         storeServiceB.getStateChannel(multisigAddress),
       ]);
-      expect(newChannelA!).to.deep.eq(newChannelB!);
-      expect(newAppInstanceA!).to.deep.eq(newAppInstanceB!);
+      expect(newChannelA!).to.containSubset(newChannelB!);
+      expect(newAppInstanceA!).to.containSubset(newAppInstanceB!);
       expect(newAppInstanceA!.identityHash).to.eq(identityHash);
       expect(newAppInstanceA!.appSeqNo).to.eq(3);
       expect(newAppInstanceA!.latestVersionNumber).to.eq(1);
@@ -991,12 +991,12 @@ describe("Sync", () => {
       ]);
 
       const syncedChannel = await storeServiceA.getStateChannel(multisigAddress);
-      expect(eventData).to.deep.eq({
+      expect(eventData).to.containSubset({
         from: nodeA.publicIdentifier,
         type: EventNames.SYNC,
         data: { syncedChannel: expectedChannel },
       });
-      expect(syncedChannel).to.deep.eq(expectedChannel!);
+      expect(syncedChannel).to.containSubset(expectedChannel!);
 
       // create new app
       [identityHash] = await installApp(nodeB, newNodeA as CFCore, multisigAddress, TicTacToeApp);
@@ -1008,8 +1008,8 @@ describe("Sync", () => {
         storeServiceA.getStateChannel(multisigAddress),
         storeServiceB.getStateChannel(multisigAddress),
       ]);
-      expect(newChannelA!).to.deep.eq(newChannelB!);
-      expect(newAppInstanceA!).to.deep.eq(newAppInstanceB!);
+      expect(newChannelA!).to.containSubset(newChannelB!);
+      expect(newAppInstanceA!).to.containSubset(newAppInstanceB!);
       expect(newAppInstanceB!.identityHash).to.eq(identityHash);
       expect(newAppInstanceB!.appSeqNo).to.eq(3);
       expect(newAppInstanceB!.latestVersionNumber).to.eq(1);
@@ -1030,8 +1030,8 @@ describe("Sync", () => {
         storeServiceA.getStateChannel(multisigAddress),
         storeServiceB.getStateChannel(multisigAddress),
       ]);
-      expect(newChannelA!).to.deep.eq(newChannelB!);
-      expect(newAppInstanceA!).to.deep.eq(newAppInstanceB!);
+      expect(newChannelA!).to.containSubset(newChannelB!);
+      expect(newAppInstanceA!).to.containSubset(newAppInstanceB!);
       expect(newAppInstanceA!.identityHash).to.eq(identityHash);
       expect(newAppInstanceA!.appSeqNo).to.eq(3);
       expect(newAppInstanceA!.latestVersionNumber).to.eq(1);
@@ -1052,8 +1052,8 @@ describe("Sync", () => {
         storeServiceA.getStateChannel(multisigAddress),
         storeServiceB.getStateChannel(multisigAddress),
       ]);
-      expect(newChannelA!).to.deep.eq(newChannelB!);
-      expect(newAppInstanceA!).to.deep.eq(newAppInstanceB!);
+      expect(newChannelA!).to.containSubset(newChannelB!);
+      expect(newAppInstanceA!).to.containSubset(newAppInstanceB!);
       expect(newAppInstanceB!.identityHash).to.eq(identityHash);
       expect(newAppInstanceB!.appSeqNo).to.eq(3);
       expect(newAppInstanceB!.latestVersionNumber).to.eq(1);
@@ -1122,7 +1122,7 @@ describe("Sync", () => {
       await uninstallApp(nodeA, nodeB, appIdentityHash, multisigAddress);
       const newChannelA = await storeServiceA.getStateChannel(multisigAddress);
       const newChannelB = await storeServiceB.getStateChannel(multisigAddress);
-      expect(newChannelA!).to.deep.eq(newChannelB!);
+      expect(newChannelA!).to.containSubset(newChannelB!);
       expect(newChannelB!.appInstances.length).to.eq(0);
       expect(newChannelB!.freeBalanceAppInstance!.latestVersionNumber).to.eq(3);
       expect(newChannelB!.monotonicNumProposedApps).to.eq(2);
@@ -1134,7 +1134,7 @@ describe("Sync", () => {
       await uninstallApp(nodeB, nodeA, appIdentityHash, multisigAddress);
       const newChannelA = await storeServiceA.getStateChannel(multisigAddress);
       const newChannelB = await storeServiceB.getStateChannel(multisigAddress);
-      expect(newChannelA!).to.deep.eq(newChannelB!);
+      expect(newChannelA!).to.containSubset(newChannelB!);
       expect(newChannelB!.appInstances.length).to.eq(0);
       expect(newChannelB!.freeBalanceAppInstance!.latestVersionNumber).to.eq(3);
       expect(newChannelB!.monotonicNumProposedApps).to.eq(2);

--- a/modules/cf-core/src/testing/scenarios/uninstall-with-action.spec.ts
+++ b/modules/cf-core/src/testing/scenarios/uninstall-with-action.spec.ts
@@ -39,6 +39,7 @@ function assertUninstallMessage(
   uninstalledApp: AppInstanceJson,
   action: AppAction,
   msg: ProtocolEventMessage<"UNINSTALL_EVENT">,
+  protocolMeta?: any,
 ) {
   assertMessage<typeof EventNames.UNINSTALL_EVENT>(msg, {
     from: senderId,
@@ -48,6 +49,7 @@ function assertUninstallMessage(
       multisigAddress,
       uninstalledApp,
       action,
+      protocolMeta,
     },
   });
 }
@@ -110,6 +112,8 @@ describe("Node A and B install an app, then uninstall with a given action", () =
       )
       .toJson();
 
+    const protocolMeta = { hello: "world" };
+
     await Promise.all([
       new Promise(async (resolve, reject) => {
         nodeA.on(EventNames.UNINSTALL_EVENT, async (msg) => {
@@ -124,6 +128,7 @@ describe("Node A and B install an app, then uninstall with a given action", () =
               expected,
               action,
               msg,
+              protocolMeta,
             );
 
             const balancesSeenByB = await getFreeBalanceState(nodeB, multisigAddress);
@@ -139,7 +144,7 @@ describe("Node A and B install an app, then uninstall with a given action", () =
       new Promise(async (resolve, reject) => {
         try {
           await nodeB.rpcRouter.dispatch(
-            constructUninstallRpc(appIdentityHash, multisigAddress, action),
+            constructUninstallRpc(appIdentityHash, multisigAddress, action, protocolMeta),
           );
 
           const balancesSeenByA = await getFreeBalanceState(nodeA, multisigAddress);

--- a/modules/cf-core/src/testing/utils.ts
+++ b/modules/cf-core/src/testing/utils.ts
@@ -635,12 +635,14 @@ export function constructUninstallRpc(
   appIdentityHash: string,
   multisigAddress: string,
   action?: SolidityValueType,
+  protocolMeta?: any,
 ): Rpc {
   return {
     parameters: {
       appIdentityHash,
       multisigAddress,
       action,
+      protocolMeta,
     } as MethodParams.Uninstall,
     id: Date.now(),
     methodName: MethodNames.chan_uninstall,

--- a/modules/client/src/controllers/WithdrawalController.ts
+++ b/modules/client/src/controllers/WithdrawalController.ts
@@ -83,6 +83,7 @@ export class WithdrawalController extends AbstractController {
         (data) => data.uninstalledApp.identityHash === withdrawAppId,
       );
 
+      // TODO: if no transaction, we should probably send it ourselves?
       transaction = await this.connext.ethProvider.getTransaction(
         uninstallEvent.protocolMeta?.withdrawTx,
       );

--- a/modules/client/src/controllers/WithdrawalController.ts
+++ b/modules/client/src/controllers/WithdrawalController.ts
@@ -208,13 +208,14 @@ export class WithdrawalController extends AbstractController {
   public async saveWithdrawCommitmentToStore(
     params: PublicParams.Withdraw,
     signatures: string[],
+    withdrawTx: any,
   ): Promise<void> {
     // set the withdrawal tx in the store
     const commitment = await this.createWithdrawCommitment(params);
     await commitment.addSignatures(signatures[0], signatures[1]);
     const minTx: MinimalTransaction = await commitment.getSignedTransaction();
     await this.connext.channelProvider.send(ChannelMethods.chan_setUserWithdrawal, {
-      withdrawalObject: { tx: minTx, retry: 0 },
+      withdrawalObject: { tx: minTx, retry: 0, withdrawTx },
     });
     return;
   }

--- a/modules/client/src/listener.ts
+++ b/modules/client/src/listener.ts
@@ -169,6 +169,7 @@ export class ConnextListener {
         msg.from,
         msg.data.action as AppAction,
         msg.data.uninstalledApp,
+        msg.data.protocolMeta,
       );
       this.emitAndLog(UNINSTALL_EVENT, msg.data);
     },
@@ -461,6 +462,7 @@ export class ConnextListener {
     from: string,
     action?: AppAction,
     appContext?: AppInstanceJson,
+    protocolMeta?: any,
   ): Promise<void> => {
     const appInstance =
       appContext || ((await this.connext.getAppInstance(appIdentityHash)) || {}).appInstance;
@@ -484,7 +486,11 @@ export class ConnextListener {
             assetId: appInstance.outcomeInterpreterParameters["tokenAddress"],
             nonce: withdrawState.nonce,
           };
-          await this.connext.saveWithdrawCommitmentToStore(params, withdrawState.signatures);
+          await this.connext.saveWithdrawCommitmentToStore(
+            params,
+            withdrawState.signatures,
+            protocolMeta.withdrawTx,
+          );
         }
         break;
       }

--- a/modules/node/src/cfCore/cfCore.service.ts
+++ b/modules/node/src/cfCore/cfCore.service.ts
@@ -374,6 +374,12 @@ export class CFCoreService {
     });
 
     this.logCfCoreMethodResult(MethodNames.chan_uninstall, uninstallResponse.result.result);
+    // TODO: this is only here for channelProvider, fix this eventually
+    const uninstallSubject = `${this.cfCore.publicIdentifier}.channel.${multisigAddress}.app-instance.${appIdentityHash}.uninstall`;
+    await this.messagingService.publish(uninstallSubject, {
+      ...uninstallResponse.result.result,
+      protocolMeta,
+    });
     return uninstallResponse.result.result as MethodResults.Uninstall;
   }
 

--- a/modules/node/src/cfCore/cfCore.service.ts
+++ b/modules/node/src/cfCore/cfCore.service.ts
@@ -358,11 +358,13 @@ export class CFCoreService {
     appIdentityHash: string,
     multisigAddress: string,
     action?: AppAction,
+    protocolMeta?: any,
   ): Promise<MethodResults.Uninstall> {
     const parameters = {
       appIdentityHash,
       multisigAddress,
       action,
+      protocolMeta,
     } as MethodParams.Uninstall;
     this.logCfCoreMethodStart(MethodNames.chan_uninstall, parameters);
     const uninstallResponse = await this.cfCore.rpcRouter.dispatch({

--- a/modules/node/src/withdraw/withdraw.service.ts
+++ b/modules/node/src/withdraw/withdraw.service.ts
@@ -97,18 +97,24 @@ export class WithdrawService {
       counterpartySignatureOnWithdrawCommitment,
     );
 
-    await this.cfCoreService.uninstallApp(appInstance.identityHash, appInstance.multisigAddress, {
-      signature: counterpartySignatureOnWithdrawCommitment,
-    } as WithdrawAppAction);
-
     await generatedCommitment.addSignatures(
       counterpartySignatureOnWithdrawCommitment, // our sig
       state.signatures[0], // user sig
     );
+
     const signedWithdrawalCommitment = await generatedCommitment.getSignedTransaction();
     const onchainTransaction = await this.submitWithdrawToChain(
       appInstance.multisigAddress,
       signedWithdrawalCommitment,
+    );
+
+    await this.cfCoreService.uninstallApp(
+      appInstance.identityHash,
+      appInstance.multisigAddress,
+      {
+        signature: counterpartySignatureOnWithdrawCommitment,
+      } as WithdrawAppAction,
+      { withdrawTx: onchainTransaction.hash },
     );
 
     // Update db entry again

--- a/modules/test-runner/src/clientConnect/clientConnect.test.ts
+++ b/modules/test-runner/src/clientConnect/clientConnect.test.ts
@@ -14,7 +14,7 @@ import {
   ETH_AMOUNT_SM,
 } from "../util";
 
-const { AddressZero, One } = constants;
+const { AddressZero, One, HashZero } = constants;
 const { hexlify, randomBytes } = utils;
 
 describe("Client Connect", () => {
@@ -127,6 +127,7 @@ describe("Client Connect", () => {
         data: hexlify(randomBytes(32)),
       },
       retry: 0,
+      withdrawalTx: HashZero,
     });
     expect(await createClient({ signer: pk, store })).rejectedWith("Something");
   });

--- a/modules/types/src/events.ts
+++ b/modules/types/src/events.ts
@@ -104,6 +104,7 @@ const INSTALL_EVENT = "INSTALL_EVENT";
 type InstallEventData = {
   appIdentityHash: Bytes32;
   appInstance: AppInstanceJson;
+  protocolMeta?: any;
 };
 
 const INSTALL_FAILED_EVENT = "INSTALL_FAILED_EVENT";
@@ -119,6 +120,7 @@ const PROPOSE_INSTALL_EVENT = "PROPOSE_INSTALL_EVENT";
 type ProposeEventData = {
   params: ProtocolParams.Propose;
   appInstanceId: string;
+  protocolMeta?: any;
 };
 
 const PROPOSE_INSTALL_FAILED_EVENT = "PROPOSE_INSTALL_FAILED_EVENT";
@@ -147,6 +149,7 @@ type UninstallEventData = {
   multisigAddress: string;
   uninstalledApp: AppInstanceJson;
   action?: SolidityValueType;
+  protocolMeta?: any;
 };
 
 const UNINSTALL_FAILED_EVENT = "UNINSTALL_FAILED_EVENT";
@@ -163,6 +166,7 @@ type UpdateStateEventData = {
   appIdentityHash: Bytes32;
   newState: SolidityValueType;
   action?: SolidityValueType;
+  protocolMeta?: any;
 };
 
 const UPDATE_STATE_FAILED_EVENT = "UPDATE_STATE_FAILED_EVENT";
@@ -176,7 +180,7 @@ type UpdateStateFailedEventData = {
 const WITHDRAWAL_CONFIRMED_EVENT = "WITHDRAWAL_CONFIRMED_EVENT";
 
 type WithdrawalConfirmedEventData = {
-  transaction: providers.TransactionResponse;
+  transaction: providers.TransactionReceipt;
 };
 
 ////////////////////////////////////////

--- a/modules/types/src/methods.ts
+++ b/modules/types/src/methods.ts
@@ -134,6 +134,7 @@ type GetStateChannelResult = {
 type InstallParams = {
   appIdentityHash: Bytes32;
   multisigAddress: Address;
+  protocolMeta?: any;
 };
 
 type InstallResult = {
@@ -168,6 +169,7 @@ type ProposeInstallParams = {
   responderDeposit: BigNumber;
   responderDepositAssetId: AssetId;
   stateTimeout?: BigNumber;
+  protocolMeta?: any;
 };
 
 type ProposeInstallResult = {
@@ -191,6 +193,7 @@ type TakeActionParams = {
   action: SolidityValueType;
   multisigAddress: Address;
   stateTimeout?: BigNumber;
+  protocolMeta?: any;
 };
 
 type TakeActionResult = {
@@ -203,6 +206,7 @@ type UninstallParams = {
   appIdentityHash: Bytes32;
   multisigAddress: Address;
   action?: SolidityValueType;
+  protocolMeta?: any;
 };
 
 type UninstallResult = {
@@ -252,6 +256,7 @@ type WithdrawCommitmentResult = {
 
 type SyncParams = {
   multisigAddress: Address;
+  protocolMeta?: any;
 };
 
 type SyncResult = {

--- a/modules/types/src/protocol.ts
+++ b/modules/types/src/protocol.ts
@@ -16,6 +16,7 @@ type InstallProtocolParams = {
   responderIdentifier: PublicIdentifier; // protocol-specific
   proposal: AppInstanceJson;
   multisigAddress: Address;
+  protocolMeta?: any;
 };
 
 type ProposeProtocolParams = {
@@ -32,7 +33,8 @@ type ProposeProtocolParams = {
   stateTimeout: BigNumber; // optional in api, but should be defined in protocol
   initialState: SolidityValueType;
   outcomeType: OutcomeType;
-  meta?: Object;
+  meta?: any;
+  protocolMeta?: any;
 };
 
 type SetupProtocolParams = {
@@ -40,6 +42,7 @@ type SetupProtocolParams = {
   responderIdentifier: PublicIdentifier;
   multisigAddress: Address;
   chainId: number;
+  protocolMeta?: any;
 };
 
 // NOTE: should only provide the appIdentityHash if the protocol
@@ -51,6 +54,7 @@ type SyncProtocolParams = {
   responderIdentifier: PublicIdentifier;
   multisigAddress: Address;
   appIdentityHash: HexString | undefined;
+  protocolMeta?: any;
 };
 
 type TakeActionProtocolParams = {
@@ -60,6 +64,7 @@ type TakeActionProtocolParams = {
   appIdentityHash: Address;
   action: SolidityValueType;
   stateTimeout: BigNumber;
+  protocolMeta?: any;
 };
 
 type UninstallProtocolParams = {
@@ -70,6 +75,7 @@ type UninstallProtocolParams = {
   blockNumberToUseIfNecessary?: number;
   action?: SolidityValueType;
   stateTimeout?: BigNumber;
+  protocolMeta?: any;
 };
 
 ////////////////////////////////////////

--- a/modules/types/src/store.ts
+++ b/modules/types/src/store.ts
@@ -25,6 +25,7 @@ export interface IBackupService {
 export type WithdrawalMonitorObject = {
   retry: number;
   tx: MinimalTransaction;
+  withdrawalTx: string;
 };
 
 export const STORE_SCHEMA_VERSION = 1;


### PR DESCRIPTION
<!--- Make sure your title is descriptive -->
<!--- If you have any questions, don't hesitate to reach out to us on Discord! -->

## The Problem
#1347 

## The Solution
* Create a concept of `protocolMeta` that can be passed from initiator to responder (emitted in events).
* Change node withdrawal service to submit withdrawal tx before uninstalling withdrawal app, and pass in the withdrawal tx hash into uninstall as `protocolMeta`.
* Change client withdrawal to pull out tx hash from event data and wait for tx rather than waiting for arbitrary data.

Still TODO:
* Fix waiting for active withdrawals. Should probably have the client store the tx hash with the withdrawal data and use that to wait for the withdrawal.

## Checklist:
<!--- Go over each of the following points & put an `x` in all the boxes that apply. -->
- [ ] I am making this PR against staging, not master
- [ ] My code follows the code style of this project.
- [ ] I have described any backwards-incompatibility implications above.
- [ ] I have highlighted which parts of the code should be reviewed most carefully.
- [ ] If my change requires a change to the documentation, I have updated it accordingly.

<!--- For each unchecked box above, briefly mention why it's unchecked -->
