### PR TITLE
Xud hotfix

### DIFF
--- a/modules/node/src/onchainTransactions/onchainTransaction.service.ts
+++ b/modules/node/src/onchainTransactions/onchainTransaction.service.ts
@@ -115,21 +115,27 @@ export class OnchainTransactionService implements OnModuleInit {
     json: StateChannelJSON,
   ): Promise<TransactionReceipt> {
     const channel = await this.channelRepository.findByMultisigAddressOrThrow(json.multisigAddress);
-    await this.queues
-      .get(channel.chainId)
-      .add(() => this.sendTransaction(transaction, TransactionReason.MULTISIG_DEPLOY, channel));
-    const tx = await this.onchainTransactionRepository.findLatestTransactionToChannel(
-      channel.multisigAddress,
-      TransactionReason.MULTISIG_DEPLOY,
-    );
+    const tx: OnchainTransactionResponse = await new Promise((resolve, reject) => {
+      this.queues.get(channel.chainId).add(() => {
+        this.sendTransaction(transaction, TransactionReason.MULTISIG_DEPLOY, channel)
+          .then((result) => resolve(result))
+          .catch((error) => reject(error.message));
+      });
+    });
+    // make sure to wait for the transaction to be completed here, since
+    // the multisig deployment is followed by a call to `getOwners`.
+    // and since the cf-core transaction service expects the tx to be
+    // mined
+    await tx.completed();
+    const stored = await this.onchainTransactionRepository.findByHash(tx.hash);
     return {
-      to: tx.to,
-      from: tx.from,
-      gasUsed: tx.gasUsed,
-      logsBloom: tx.logsBloom,
-      blockHash: tx.blockHash,
-      transactionHash: tx.hash,
-      blockNumber: tx.blockNumber,
+      to: stored.to,
+      from: stored.from,
+      gasUsed: stored.gasUsed,
+      logsBloom: stored.logsBloom,
+      blockHash: stored.blockHash,
+      transactionHash: stored.hash,
+      blockNumber: stored.blockNumber,
     } as TransactionReceipt;
   }
 

--- a/modules/node/src/withdraw/withdraw.service.ts
+++ b/modules/node/src/withdraw/withdraw.service.ts
@@ -25,7 +25,10 @@ import {
   TransactionReason,
 } from "../onchainTransactions/onchainTransaction.entity";
 import { OnchainTransactionRepository } from "../onchainTransactions/onchainTransaction.repository";
-import { OnchainTransactionService } from "../onchainTransactions/onchainTransaction.service";
+import {
+  OnchainTransactionService,
+  OnchainTransactionResponse,
+} from "../onchainTransactions/onchainTransaction.service";
 
 import { WithdrawRepository } from "./withdraw.repository";
 import { Withdraw } from "./withdraw.entity";
@@ -192,7 +195,7 @@ export class WithdrawService {
     tx: MinimalTransaction,
     appIdentityHash: string,
     withdrawReason: TransactionReason.NODE_WITHDRAWAL | TransactionReason.USER_WITHDRAWAL,
-  ): Promise<providers.TransactionResponse> {
+  ): Promise<OnchainTransactionResponse> {
     this.log.info(`submitWithdrawToChain for ${multisigAddress}`);
     const channel = await this.channelRepository.findByMultisigAddressOrThrow(multisigAddress);
 
@@ -211,7 +214,7 @@ export class WithdrawService {
     }
 
     this.log.info(`Sending withdrawal to chain`);
-    let txRes: providers.TransactionResponse;
+    let txRes: OnchainTransactionResponse;
     if (withdrawReason === TransactionReason.NODE_WITHDRAWAL) {
       txRes = await this.onchainTransactionService.sendWithdrawal(channel, tx, appIdentityHash);
     } else {


### PR DESCRIPTION
## The Problem
Not waiting for multisig deployment tx to be properly mined, meaning the `getOwners` call will throw an exception and cause withdrawal failures

## The Solution
Wait for tx to be mined in the transaction service

## Checklist:
<!--- Go over each of the following points & put an `x` in all the boxes that apply. -->
- [ ] I am making this PR against staging, not master
- [ ] My code follows the code style of this project.
- [ ] I have described any backwards-incompatibility implications above.
- [ ] I have highlighted which parts of the code should be reviewed most carefully.
- [ ] If my change requires a change to the documentation, I have updated it accordingly.

<!--- For each unchecked box above, briefly mention why it's unchecked -->
