### PR TITLE
Hotfix add appid if failed

### DIFF
--- a/modules/node/src/onchainTransactions/onchainTransaction.repository.ts
+++ b/modules/node/src/onchainTransactions/onchainTransaction.repository.ts
@@ -162,12 +162,14 @@ export class OnchainTransactionRepository extends Repository<OnchainTransaction>
   async markFailed(
     tx: providers.TransactionResponse,
     errors: { [k: number]: string },
+    appIdentityHash?: string,
   ): Promise<void> {
     return getManager().transaction(async (transactionalEntityManager) => {
       await transactionalEntityManager
         .createQueryBuilder()
         .update(OnchainTransaction)
         .set({
+          appIdentityHash,
           status: TransactionStatus.FAILED,
           errors,
         })

--- a/modules/node/src/onchainTransactions/onchainTransaction.service.ts
+++ b/modules/node/src/onchainTransactions/onchainTransaction.service.ts
@@ -209,7 +209,7 @@ export class OnchainTransactionService implements OnModuleInit {
         );
       }
     }
-    await this.onchainTransactionRepository.markFailed(tx, errors);
+    await this.onchainTransactionRepository.markFailed(tx, errors, appIdentityHash);
     throw new Error(`Failed to send transaction (errors indexed by attempt): ${stringify(errors)}`);
   }
 


### PR DESCRIPTION
## The Problem
Fixes problem where transactions that fail are not associated with an appId.

## The Solution
Add appId on failures as well

## Checklist:
<!--- Go over each of the following points & put an `x` in all the boxes that apply. -->
- [ ] I am making this PR against staging, not master
- [ ] My code follows the code style of this project.
- [ ] I have described any backwards-incompatibility implications above.
- [ ] I have highlighted which parts of the code should be reviewed most carefully.
- [ ] If my change requires a change to the documentation, I have updated it accordingly.

<!--- For each unchecked box above, briefly mention why it's unchecked -->
